### PR TITLE
v6.2 (20200309)

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -53,7 +53,7 @@ ui_print ""
 ui_print "* QTI memory optimization"
 ui_print "* https://github.com/yc9559/qti-mem-opt"
 ui_print "* Author: Matt Yang"
-ui_print "* Version: v6.1 (20200229)"
+ui_print "* Version: v6.2 (20200309)"
 ui_print ""
 
 # Only some special files require specific permissions

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=qti-mem-opt
 name=QTI memory optimization
-version=v6.1 (20200229)
+version=v6.2 (20200309)
 versionCode=5
 author=Matt Yang
 description=Memory management optimaization for Android platforms. Repo: https://github.com/yc9559/qti-mem-opt


### PR DESCRIPTION
改进：当检测不是 Android LMK 的时候，不再修改 LMK,ZRAM,VM虚拟机 相关设置，仅仅保留 fscc 和 Adjshield 工作

一般情况下使用 Simple LMK 的内核，都会对 ZRAM，VM虚拟机 相关进行调整，所以为了更好的让 Simple_LMK 工作，仅仅保留 fscc 和 Adjshield 工作